### PR TITLE
Added rate limiting in the RPC Server

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -8,8 +8,8 @@ Package rpcmq implements an RPC protocol over AMQP.
 Client/Server initialization
 
 It is important to note that both clients and servers must be initialized
-before being used. Also, any configuration parameter (TLSConfig, Parallel and
-Prefetch) should be set up before calling Init().
+before being used. Also, any configuration parameter (TLSConfig, Parallel,
+Prefetch and RateLimit) should be set up before calling Init().
 
 SSL/TLS
 


### PR DESCRIPTION
I just added a simple rate limiting feature in the RPC server that allows to specify a limit of x calls per second by setting the variable RateLimit to x before calling Init()
