### PR TITLE
Make DeliveryMode configurable

### DIFF
--- a/client.go
+++ b/client.go
@@ -25,6 +25,7 @@ type Client struct {
 	repliesQueue amqp.Queue
 	mandatory    bool
 	deliveries   <-chan amqp.Delivery
+	DeliveryMode uint8
 	results      chan Result
 
 	// TLSConfig allows to configure the TLS parameters used to connect to
@@ -63,6 +64,7 @@ func NewClient(uri, msgsQueue, repliesQueue, exchange, kind string) *Client {
 		exchangeKind: kind,
 		ac:           newAmqpClient(uri),
 		results:      make(chan Result),
+		DeliveryMode: amqp.Persistent,
 	}
 	c.ac.setupFunc = c.setup
 	return c
@@ -224,7 +226,7 @@ func (c *Client) Call(method string, data []byte, ttl time.Duration) (id string,
 			ReplyTo:       c.repliesQueue.Name,
 			ContentType:   "application/json",
 			Body:          body,
-			DeliveryMode:  amqp.Persistent,
+			DeliveryMode:  c.DeliveryMode,
 			Expiration:    expiration,
 		},
 	)

--- a/doc.go
+++ b/doc.go
@@ -9,7 +9,7 @@ Client/Server initialization
 
 It is important to note that both clients and servers must be initialized
 before being used. Also, any configuration parameter (TLSConfig, Parallel,
-Prefetch and RateLimit) should be set up before calling Init().
+Prefetch, RateLimit and DeliveryMode) should be set up before calling Init().
 
 SSL/TLS
 

--- a/server.go
+++ b/server.go
@@ -34,6 +34,8 @@ type Server struct {
 	wg              sync.WaitGroup
 	parallelMethods chan bool
 	deliveries      <-chan amqp.Delivery
+	// Delivery mode (amqp.Transient or amqp.Persistent)
+	DeliveryMode uint8
 
 	// Parallel allows to define the number of methods to be run in
 	// parallel
@@ -69,6 +71,7 @@ func NewServer(uri, msgsQueue, exchange, kind string) *Server {
 		Parallel:     runtime.NumCPU(),
 		Prefetch:     runtime.NumCPU(),
 		RateLimit:    0,
+		DeliveryMode: amqp.Persistent,
 	}
 	s.ac.setupFunc = s.setup
 	return s
@@ -240,7 +243,7 @@ func (s *Server) handleDelivery(d amqp.Delivery) {
 			ReplyTo:       d.ReplyTo,
 			ContentType:   "application/json",
 			Body:          body,
-			DeliveryMode:  amqp.Persistent,
+			DeliveryMode:  s.DeliveryMode,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
Allow DeliveryMode to be configurable (amqp.Persistent or amqp.Transient) in both Client and Server.
